### PR TITLE
fix(kcenon-pacs-system): disable FetchContent fallbacks for vcpkg builds

### DIFF
--- a/ports/kcenon-pacs-system/portfile.cmake
+++ b/ports/kcenon-pacs-system/portfile.cmake
@@ -25,6 +25,10 @@ vcpkg_cmake_configure(
         -DPACS_BUILD_MODULES=OFF
         -DPACS_WARNINGS_AS_ERRORS=OFF
         -DBUILD_SHARED_LIBS=OFF
+        # Disable all FetchContent fallbacks; all deps must be resolved via vcpkg
+        -DPACS_FETCH_OPENJPH=OFF
+        -DPACS_FETCH_CROW=OFF
+        -DFETCHCONTENT_FULLY_DISCONNECTED=ON
 )
 
 vcpkg_cmake_install()


### PR DESCRIPTION
## What

Add three CMake options to `vcpkg_cmake_configure` in the `kcenon-pacs-system` portfile to prevent any FetchContent network downloads during the port build:

| Option | Effect |
|--------|--------|
| `PACS_FETCH_OPENJPH=OFF` | Disables OpenJPH FetchContent fallback |
| `PACS_FETCH_CROW=OFF` | Disables Crow + ASIO FetchContent fallback |
| `FETCHCONTENT_FULLY_DISCONNECTED=ON` | CMake global guard — fails any FetchContent call that reaches the network |

## Why

vcpkg's reproducibility guarantee requires all source downloads to be handled by vcpkg itself (with SHA512 verification). FetchContent downloads during the port build bypass version pinning, cannot be verified, and fail in offline/CI environments where `FETCHCONTENT_FULLY_DISCONNECTED=ON` is standard.

Relates to kcenon/pacs_system#946

## Where

- `ports/kcenon-pacs-system/portfile.cmake`

## How

### Changes
- Three `-D` options appended to `vcpkg_cmake_configure OPTIONS` block
- No source changes required — flags control existing `option()` guards in `CMakeLists.txt`

### Test Plan
- [ ] `vcpkg install kcenon-pacs-system` succeeds without network access after this change
- [ ] CI build with `FETCHCONTENT_FULLY_DISCONNECTED=ON` does not attempt any downloads