### PR TITLE
fix(ports): add snake_case find_package wrappers and openjph codec

### DIFF
--- a/ports/kcenon-container-system/portfile.cmake
+++ b/ports/kcenon-container-system/portfile.cmake
@@ -29,6 +29,17 @@ vcpkg_cmake_config_fixup(
     CONFIG_PATH lib/cmake/ContainerSystem
 )
 
+# Create snake_case wrapper so find_package(container_system CONFIG) also works
+# Upstream issue: kcenon/container_system#424
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/container_system-config.cmake"
+    "include(\"\${CMAKE_CURRENT_LIST_DIR}/ContainerSystemConfig.cmake\")\n"
+)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/${PORT}/ContainerSystemConfigVersion.cmake")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/container_system-config-version.cmake"
+        "include(\"\${CMAKE_CURRENT_LIST_DIR}/ContainerSystemConfigVersion.cmake\")\n"
+    )
+endif()
+
 # Remove example/sample executables and empty bin directories
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/bin/examples"

--- a/ports/kcenon-database-system/portfile.cmake
+++ b/ports/kcenon-database-system/portfile.cmake
@@ -55,6 +55,17 @@ vcpkg_cmake_config_fixup(
     CONFIG_PATH lib/cmake/DatabaseSystem
 )
 
+# Create snake_case wrapper so find_package(database_system CONFIG) also works
+# Upstream issue: kcenon/database_system#455
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/database_system-config.cmake"
+    "include(\"\${CMAKE_CURRENT_LIST_DIR}/DatabaseSystemConfig.cmake\")\n"
+)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/${PORT}/DatabaseSystemConfigVersion.cmake")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/database_system-config-version.cmake"
+        "include(\"\${CMAKE_CURRENT_LIST_DIR}/DatabaseSystemConfigVersion.cmake\")\n"
+    )
+endif()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 

--- a/ports/kcenon-logger-system/portfile.cmake
+++ b/ports/kcenon-logger-system/portfile.cmake
@@ -30,6 +30,16 @@ vcpkg_cmake_config_fixup(
     CONFIG_PATH lib/cmake/LoggerSystem
 )
 
+# Create snake_case wrapper so find_package(logger_system CONFIG) also works
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/logger_system-config.cmake"
+    "include(\"\${CMAKE_CURRENT_LIST_DIR}/LoggerSystemConfig.cmake\")\n"
+)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/${PORT}/LoggerSystemConfigVersion.cmake")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/logger_system-config-version.cmake"
+        "include(\"\${CMAKE_CURRENT_LIST_DIR}/LoggerSystemConfigVersion.cmake\")\n"
+    )
+endif()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 

--- a/ports/kcenon-network-system/portfile.cmake
+++ b/ports/kcenon-network-system/portfile.cmake
@@ -35,6 +35,17 @@ vcpkg_cmake_config_fixup(
     CONFIG_PATH lib/cmake/NetworkSystem
 )
 
+# Create snake_case wrapper so find_package(network_system CONFIG) also works
+# Upstream issue: kcenon/network_system#843
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/network_system-config.cmake"
+    "include(\"\${CMAKE_CURRENT_LIST_DIR}/NetworkSystemConfig.cmake\")\n"
+)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/${PORT}/NetworkSystemConfigVersion.cmake")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/network_system-config-version.cmake"
+        "include(\"\${CMAKE_CURRENT_LIST_DIR}/NetworkSystemConfigVersion.cmake\")\n"
+    )
+endif()
+
 # Remove empty directories that cause vcpkg post-build validation warnings
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/include/kcenon/network/core"

--- a/ports/kcenon-pacs-system/vcpkg.json
+++ b/ports/kcenon-pacs-system/vcpkg.json
@@ -47,6 +47,10 @@
         {
           "name": "charls",
           "version>=": "2.4.2"
+        },
+        {
+          "name": "openjph",
+          "version>=": "0.21.0"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Add snake_case `find_package()` config wrappers for 4 PascalCase systems and add missing `openjph` codec to pacs_system.

## Changes

**Snake_case wrappers** (4 portfiles):
- `logger_system-config.cmake` → includes `LoggerSystemConfig.cmake`
- `container_system-config.cmake` → includes `ContainerSystemConfig.cmake`
- `database_system-config.cmake` → includes `DatabaseSystemConfig.cmake`
- `network_system-config.cmake` → includes `NetworkSystemConfig.cmake`

Both `find_package(container_system CONFIG)` and `find_package(ContainerSystem CONFIG)` now work.

**openjph codec** (pacs_system vcpkg.json):
- Added `openjph >= 0.21.0` to codecs feature, matching project vcpkg.json

## Test plan

- Companion PR on monitoring_system: kcenon/monitoring_system#557
- CI consumer test updated to REQUIRED for all 8 find_package() calls

Related: kcenon/monitoring_system#554, kcenon/monitoring_system#556