### PR TITLE
chore(ports): Remove obsolete PascalCase wrapper code

### DIFF
--- a/ports/kcenon-container-system/portfile.cmake
+++ b/ports/kcenon-container-system/portfile.cmake
@@ -25,20 +25,9 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME ContainerSystem
-    CONFIG_PATH lib/cmake/ContainerSystem
+    PACKAGE_NAME container_system
+    CONFIG_PATH lib/cmake/container_system
 )
-
-# Create snake_case wrapper so find_package(container_system CONFIG) also works
-# Upstream issue: kcenon/container_system#424
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/container_system-config.cmake"
-    "include(\"\${CMAKE_CURRENT_LIST_DIR}/ContainerSystemConfig.cmake\")\n"
-)
-if(EXISTS "${CURRENT_PACKAGES_DIR}/share/${PORT}/ContainerSystemConfigVersion.cmake")
-    file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/container_system-config-version.cmake"
-        "include(\"\${CMAKE_CURRENT_LIST_DIR}/ContainerSystemConfigVersion.cmake\")\n"
-    )
-endif()
 
 # Remove example/sample executables and empty bin directories
 file(REMOVE_RECURSE

--- a/ports/kcenon-container-system/vcpkg.json
+++ b/ports/kcenon-container-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-container-system",
   "version": "0.1.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Advanced C++20 Container System with Thread-Safe Operations and Messaging Integration",
   "homepage": "https://github.com/kcenon/container_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-database-system/portfile.cmake
+++ b/ports/kcenon-database-system/portfile.cmake
@@ -51,20 +51,9 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME DatabaseSystem
-    CONFIG_PATH lib/cmake/DatabaseSystem
+    PACKAGE_NAME database_system
+    CONFIG_PATH lib/cmake/database_system
 )
-
-# Create snake_case wrapper so find_package(database_system CONFIG) also works
-# Upstream issue: kcenon/database_system#455
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/database_system-config.cmake"
-    "include(\"\${CMAKE_CURRENT_LIST_DIR}/DatabaseSystemConfig.cmake\")\n"
-)
-if(EXISTS "${CURRENT_PACKAGES_DIR}/share/${PORT}/DatabaseSystemConfigVersion.cmake")
-    file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/database_system-config-version.cmake"
-        "include(\"\${CMAKE_CURRENT_LIST_DIR}/DatabaseSystemConfigVersion.cmake\")\n"
-    )
-endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/kcenon-database-system/vcpkg.json
+++ b/ports/kcenon-database-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-database-system",
   "version": "0.1.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Pure, lightweight C++20 Core DAL library with unified access to PostgreSQL, SQLite, MongoDB, and Redis",
   "homepage": "https://github.com/kcenon/database_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-logger-system/portfile.cmake
+++ b/ports/kcenon-logger-system/portfile.cmake
@@ -26,19 +26,9 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME LoggerSystem
-    CONFIG_PATH lib/cmake/LoggerSystem
+    PACKAGE_NAME logger_system
+    CONFIG_PATH lib/cmake/logger_system
 )
-
-# Create snake_case wrapper so find_package(logger_system CONFIG) also works
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/logger_system-config.cmake"
-    "include(\"\${CMAKE_CURRENT_LIST_DIR}/LoggerSystemConfig.cmake\")\n"
-)
-if(EXISTS "${CURRENT_PACKAGES_DIR}/share/${PORT}/LoggerSystemConfigVersion.cmake")
-    file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/logger_system-config-version.cmake"
-        "include(\"\${CMAKE_CURRENT_LIST_DIR}/LoggerSystemConfigVersion.cmake\")\n"
-    )
-endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/kcenon-logger-system/vcpkg.json
+++ b/ports/kcenon-logger-system/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kcenon-logger-system",
   "version": "0.1.3",
+  "port-version": 2,
   "description": "High-performance C++20 async logging framework with 4.34M msg/sec throughput, 148ns latency, and modular architecture",
   "homepage": "https://github.com/kcenon/logger_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-network-system/portfile.cmake
+++ b/ports/kcenon-network-system/portfile.cmake
@@ -31,20 +31,9 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME NetworkSystem
-    CONFIG_PATH lib/cmake/NetworkSystem
+    PACKAGE_NAME network_system
+    CONFIG_PATH lib/cmake/network_system
 )
-
-# Create snake_case wrapper so find_package(network_system CONFIG) also works
-# Upstream issue: kcenon/network_system#843
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/network_system-config.cmake"
-    "include(\"\${CMAKE_CURRENT_LIST_DIR}/NetworkSystemConfig.cmake\")\n"
-)
-if(EXISTS "${CURRENT_PACKAGES_DIR}/share/${PORT}/NetworkSystemConfigVersion.cmake")
-    file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/network_system-config-version.cmake"
-        "include(\"\${CMAKE_CURRENT_LIST_DIR}/NetworkSystemConfigVersion.cmake\")\n"
-    )
-endif()
 
 # Remove empty directories that cause vcpkg post-build validation warnings
 file(REMOVE_RECURSE

--- a/ports/kcenon-network-system/vcpkg.json
+++ b/ports/kcenon-network-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-network-system",
   "version": "0.1.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Modern C++20 async network library with TCP/UDP, HTTP/1.1, WebSocket, and TLS 1.3 support",
   "homepage": "https://github.com/kcenon/network_system",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10,11 +10,11 @@
     },
     "kcenon-logger-system": {
       "baseline": "0.1.3",
-      "port-version": 1
+      "port-version": 2
     },
     "kcenon-container-system": {
       "baseline": "0.1.0",
-      "port-version": 2
+      "port-version": 3
     },
     "kcenon-monitoring-system": {
       "baseline": "0.1.0",
@@ -22,11 +22,11 @@
     },
     "kcenon-database-system": {
       "baseline": "0.1.0",
-      "port-version": 3
+      "port-version": 4
     },
     "kcenon-network-system": {
       "baseline": "0.1.1",
-      "port-version": 1
+      "port-version": 2
     },
     "kcenon-pacs-system": {
       "baseline": "0.1.0",

--- a/versions/k-/kcenon-container-system.json
+++ b/versions/k-/kcenon-container-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version": "0.1.0",
+      "port-version": 3,
+      "git-tree": "8cf80db63c3c1d05624c030a15dbd930ff6f9409"
+    },
+    {
+      "version": "0.1.0",
       "port-version": 2,
       "git-tree": "8c67bf46ecf161d17e5254abb79fc6be8591e842"
     },

--- a/versions/k-/kcenon-database-system.json
+++ b/versions/k-/kcenon-database-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version": "0.1.0",
+      "port-version": 4,
+      "git-tree": "e290a298e890647d78ed3a99dfde04657b60c291"
+    },
+    {
+      "version": "0.1.0",
       "port-version": 3,
       "git-tree": "2ae3599a2f0add7ae2e80a484e8700a49656b3ed"
     },

--- a/versions/k-/kcenon-logger-system.json
+++ b/versions/k-/kcenon-logger-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version": "0.1.3",
+      "port-version": 2,
+      "git-tree": "94594a4d69d8e171383cb76ca431ffb92dd3575b"
+    },
+    {
+      "version": "0.1.3",
       "port-version": 1,
       "git-tree": "5b77580f22839a612327b4c5043e5c9d3ad4e006"
     },

--- a/versions/k-/kcenon-network-system.json
+++ b/versions/k-/kcenon-network-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version": "0.1.1",
+      "port-version": 2,
+      "git-tree": "a06e43747df36aa5a1fd62934365d4a48de4a567"
+    },
+    {
+      "version": "0.1.1",
       "port-version": 1,
       "git-tree": "919fb8d5375f1f62696f47cea1e10623b99ab372"
     },


### PR DESCRIPTION
## Summary

- Remove PascalCase → snake_case wrapper `file(WRITE ...)` code from 4 portfiles
- Update `PACKAGE_NAME` and `CONFIG_PATH` to use native snake_case values
- Bump port-version for all 4 affected ports
- Update `versions/baseline.json` and `versions/k-/*.json`

Upstream repos now natively support snake_case CMake install paths:
- kcenon/logger_system#502
- kcenon/container_system#424
- kcenon/database_system#455
- kcenon/network_system#843

| Port | Old PACKAGE_NAME | New PACKAGE_NAME | Port-Version |
|------|-----------------|-----------------|-------------|
| kcenon-logger-system | `LoggerSystem` | `logger_system` | 1 → 2 |
| kcenon-container-system | `ContainerSystem` | `container_system` | 2 → 3 |
| kcenon-database-system | `DatabaseSystem` | `database_system` | 3 → 4 |
| kcenon-network-system | `NetworkSystem` | `network_system` | 1 → 2 |

Syncs registry portfiles with `monitoring_system/vcpkg-ports/` which already uses native snake_case.

## Test plan

- [ ] `vcpkg install kcenon-logger-system` succeeds
- [ ] `vcpkg install kcenon-container-system` succeeds
- [ ] `vcpkg install kcenon-database-system` succeeds
- [ ] `vcpkg install kcenon-network-system` succeeds
- [ ] `find_package(logger_system CONFIG)` resolves without wrapper indirection
- [ ] `find_package(container_system CONFIG)` resolves without wrapper indirection
- [ ] `find_package(database_system CONFIG)` resolves without wrapper indirection
- [ ] `find_package(network_system CONFIG)` resolves without wrapper indirection

Closes #25