### PR TITLE
fix(ports): Add missing zlib dependency to kcenon-network-system

### DIFF
--- a/ports/kcenon-network-system/vcpkg.json
+++ b/ports/kcenon-network-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-network-system",
   "version": "0.1.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Modern C++20 async network library with TCP/UDP, HTTP/1.1, WebSocket, and TLS 1.3 support",
   "homepage": "https://github.com/kcenon/network_system",
   "license": "BSD-3-Clause",
@@ -11,6 +11,10 @@
     "kcenon-thread-system",
     "asio",
     "openssl",
+    {
+      "name": "zlib",
+      "version>=": "1.3"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -26,7 +26,7 @@
     },
     "kcenon-network-system": {
       "baseline": "0.1.1",
-      "port-version": 2
+      "port-version": 3
     },
     "kcenon-pacs-system": {
       "baseline": "0.1.0",

--- a/versions/k-/kcenon-network-system.json
+++ b/versions/k-/kcenon-network-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version": "0.1.1",
+      "port-version": 3,
+      "git-tree": "38ab9bd5307072fb68b501664f6f3ea81c7cd243"
+    },
+    {
+      "version": "0.1.1",
       "port-version": 2,
       "git-tree": "a06e43747df36aa5a1fd62934365d4a48de4a567"
     },


### PR DESCRIPTION
## Summary
- Add `zlib >= 1.3` to core dependencies of `kcenon-network-system` port
- Bump port-version from 2 to 3
- Update version database with new git-tree entry

## Why

The source repository (`network_system/vcpkg.json`) declares `zlib >= 1.3` as a required dependency for message compression, but the registry port omitted it. Consumers running `vcpkg install kcenon-network-system` would not get zlib installed automatically, causing build failures.

Closes #28

## Where

| File | Change |
|------|--------|
| `ports/kcenon-network-system/vcpkg.json` | Added `zlib` to `dependencies`, bumped port-version |
| `versions/baseline.json` | Updated port-version to 3 |
| `versions/k-/kcenon-network-system.json` | Added new version entry with git-tree hash |

## Test plan
- [ ] `vcpkg install kcenon-network-system` resolves zlib automatically
- [ ] Existing consumers with explicit zlib see no regression