### PR TITLE
feat(ports): add usage files for all 8 ecosystem ports

### DIFF
--- a/ports/kcenon-common-system/usage
+++ b/ports/kcenon-common-system/usage
@@ -1,0 +1,4 @@
+The package kcenon-common-system provides CMake targets:
+
+    find_package(common_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE common_system::common_system)

--- a/ports/kcenon-container-system/usage
+++ b/ports/kcenon-container-system/usage
@@ -1,0 +1,4 @@
+The package kcenon-container-system provides CMake targets:
+
+    find_package(container_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE container_system::container)

--- a/ports/kcenon-database-system/usage
+++ b/ports/kcenon-database-system/usage
@@ -1,0 +1,6 @@
+The package kcenon-database-system provides CMake targets:
+
+    find_package(database_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE database_system::database)
+
+Available features: postgresql (default), sqlite, mongodb, redis

--- a/ports/kcenon-logger-system/usage
+++ b/ports/kcenon-logger-system/usage
@@ -1,0 +1,6 @@
+The package kcenon-logger-system provides CMake targets:
+
+    find_package(logger_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE logger_system::LoggerSystem)
+
+Available features: encryption, otlp

--- a/ports/kcenon-monitoring-system/usage
+++ b/ports/kcenon-monitoring-system/usage
@@ -1,0 +1,6 @@
+The package kcenon-monitoring-system provides CMake targets:
+
+    find_package(monitoring_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE monitoring_system::monitoring_system)
+
+Available features: logging, network, grpc

--- a/ports/kcenon-network-system/usage
+++ b/ports/kcenon-network-system/usage
@@ -1,0 +1,6 @@
+The package kcenon-network-system provides CMake targets:
+
+    find_package(network_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE network_system::NetworkSystem)
+
+Available features: logging

--- a/ports/kcenon-pacs-system/usage
+++ b/ports/kcenon-pacs-system/usage
@@ -1,0 +1,13 @@
+The package kcenon-pacs-system provides CMake targets:
+
+    find_package(pacs_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE
+        pacs_system::core
+        pacs_system::encoding
+        pacs_system::network
+        pacs_system::client
+        pacs_system::services
+        pacs_system::security
+    )
+
+Available features: storage, codecs, ssl, aws, azure, rest-api

--- a/ports/kcenon-thread-system/usage
+++ b/ports/kcenon-thread-system/usage
@@ -1,0 +1,4 @@
+The package kcenon-thread-system provides CMake targets:
+
+    find_package(thread_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE thread_system::ThreadSystem)


### PR DESCRIPTION
Closes #31

## Summary

- Add `usage` files to all 8 port directories providing post-install CMake integration guidance
- Each file lists the correct `find_package()` name and `target_link_libraries()` target
- Feature-bearing ports (logger, monitoring, database, network, pacs) list available features

## Ports

| Port | Target | Features |
|------|--------|----------|
| kcenon-common-system | `common_system::common_system` | — |
| kcenon-thread-system | `thread_system::ThreadSystem` | — |
| kcenon-logger-system | `logger_system::LoggerSystem` | encryption, otlp |
| kcenon-container-system | `container_system::container` | — |
| kcenon-monitoring-system | `monitoring_system::monitoring_system` | logging, network, grpc |
| kcenon-database-system | `database_system::database` | postgresql (default), sqlite, mongodb, redis |
| kcenon-network-system | `network_system::NetworkSystem` | logging |
| kcenon-pacs-system | `pacs_system::core` + components | storage, codecs, ssl, aws, azure, rest-api |

## Test Plan

- [ ] Verify `vcpkg install kcenon-<port>` displays the usage text after installation
- [ ] Confirm `find_package()` names match actual CMake config package names
- [ ] Confirm `target_link_libraries()` targets match exported CMake target names