### PR TITLE
chore: update version database for modified ports

### DIFF
--- a/ports/kcenon-common-system/vcpkg.json
+++ b/ports/kcenon-common-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-common-system",
   "version-semver": "0.2.0",
-  "port-version": 0,
+  "port-version": 1,
   "description": "High-performance C++20 foundation library providing Result<T> pattern, interfaces, and common utilities",
   "homepage": "https://github.com/kcenon/common_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-container-system/vcpkg.json
+++ b/ports/kcenon-container-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-container-system",
   "version-semver": "0.1.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Advanced C++20 Container System with Thread-Safe Operations and Messaging Integration",
   "homepage": "https://github.com/kcenon/container_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-logger-system/vcpkg.json
+++ b/ports/kcenon-logger-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-logger-system",
   "version-semver": "0.1.3",
-  "port-version": 5,
+  "port-version": 6,
   "description": "High-performance C++20 async logging framework with 4.34M msg/sec throughput, 148ns latency, and modular architecture",
   "homepage": "https://github.com/kcenon/logger_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-network-system/vcpkg.json
+++ b/ports/kcenon-network-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-network-system",
   "version-semver": "0.1.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Modern C++20 async network library with TCP/UDP, HTTP/1.1, WebSocket, and TLS 1.3 support",
   "homepage": "https://github.com/kcenon/network_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-pacs-system/vcpkg.json
+++ b/ports/kcenon-pacs-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-pacs-system",
   "version-semver": "0.1.0",
-  "port-version": 8,
+  "port-version": 9,
   "description": "Modern C++20 PACS (Picture Archiving and Communication System) built on the kcenon ecosystem",
   "homepage": "https://github.com/kcenon/pacs_system",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2,19 +2,19 @@
   "default": {
     "kcenon-common-system": {
       "baseline": "0.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kcenon-thread-system": {
-      "baseline": "0.3.2",
+      "baseline": "0.3.1",
       "port-version": 2
     },
     "kcenon-logger-system": {
       "baseline": "0.1.3",
-      "port-version": 5
+      "port-version": 6
     },
     "kcenon-container-system": {
       "baseline": "0.1.0",
-      "port-version": 4
+      "port-version": 5
     },
     "kcenon-monitoring-system": {
       "baseline": "0.1.0",
@@ -26,11 +26,11 @@
     },
     "kcenon-network-system": {
       "baseline": "0.1.1",
-      "port-version": 6
+      "port-version": 7
     },
     "kcenon-pacs-system": {
       "baseline": "0.1.0",
-      "port-version": 8
+      "port-version": 9
     }
   }
 }

--- a/versions/k-/kcenon-common-system.json
+++ b/versions/k-/kcenon-common-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version": "0.2.0",
+      "port-version": 1,
+      "git-tree": "6e092ed853205ec1504c2e2cce95ee079bf681e7"
+    },
+    {
+      "version": "0.2.0",
       "port-version": 0,
       "git-tree": "a9ddfe0bcfa854e47d785659a1441569f3f3e7b0"
     }

--- a/versions/k-/kcenon-container-system.json
+++ b/versions/k-/kcenon-container-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version-semver": "0.1.0",
+      "port-version": 5,
+      "git-tree": "1c2a8dedbd98a4df7f70ed15237a77d9f111c58c"
+    },
+    {
+      "version-semver": "0.1.0",
       "port-version": 4,
       "git-tree": "2d04459058e429c162cc270b6a3bf05abca372f6"
     },

--- a/versions/k-/kcenon-logger-system.json
+++ b/versions/k-/kcenon-logger-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version-semver": "0.1.3",
+      "port-version": 6,
+      "git-tree": "490e3c6a4c96b90c6875fdf7215bbfe4d03b1882"
+    },
+    {
+      "version-semver": "0.1.3",
       "port-version": 5,
       "git-tree": "134050c25797967384c0ca64de4f9ef4d2a300b6"
     },

--- a/versions/k-/kcenon-network-system.json
+++ b/versions/k-/kcenon-network-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version": "0.1.1",
+      "port-version": 7,
+      "git-tree": "ae2ce0d4ffede07d2d6ffdf42669eac78faab6ee"
+    },
+    {
+      "version": "0.1.1",
       "port-version": 6,
       "git-tree": "4382993e89fe01b038078be871fa7ec047aef6d6"
     },

--- a/versions/k-/kcenon-pacs-system.json
+++ b/versions/k-/kcenon-pacs-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version-semver": "0.1.0",
+      "port-version": 9,
+      "git-tree": "a01a5bea91c1f43271be978ba6fbe73a3a332b31"
+    },
+    {
+      "version-semver": "0.1.0",
       "port-version": 8,
       "git-tree": "aa787fe98ad40e3fbf30c9bbaf291fcc9a163a98"
     },

--- a/versions/k-/kcenon-thread-system.json
+++ b/versions/k-/kcenon-thread-system.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "version": "0.3.1",
+      "port-version": 2,
+      "git-tree": "49db4df6b791a5954591f691896f758050c932b1"
+    },
+    {
       "version": "0.3.2",
       "port-version": 2,
       "git-tree": "d5719ace4588f7c19d7e1afbaa6925ea6aeba9f9"


### PR DESCRIPTION
## Summary

Update the vcpkg version database to register the current state of all 6 ports modified in PRs #66 and #67. Without this update, consumers using the registry baseline would still resolve to pre-fix git-tree SHAs, getting the old PascalCase portfiles.

Part of #59

### Changes

**Port-version bumps** (`ports/*/vcpkg.json`):
| Port | Old | New |
|------|-----|-----|
| common_system | 0.2.0#0 | 0.2.0#1 |
| logger_system | 0.1.3#5 | 0.1.3#6 |
| container_system | 0.1.0#4 | 0.1.0#5 |
| network_system | 0.1.1#6 | 0.1.1#7 |
| pacs_system | 0.1.0#8 | 0.1.0#9 |

**Baseline update** (`versions/baseline.json`):
- thread_system: 0.3.2#2 → 0.3.1#2 (version corrected)
- All other modified ports: port-version bumped

**Version entries** (`versions/k-/*.json`):
- New git-tree entries added for all 6 modified ports

## Why

The portfile fixes in PRs #66/#67 changed the port directory contents, invalidating the old git-tree SHAs. Without updating the version database, `vcpkg install` resolves to stale port content via the old baseline references.

## Test plan
- [ ] `validate-registry.yml` CI passes (git-tree validation)
- [ ] `vcpkg install kcenon-common-system` resolves correct port-version
- [ ] `vcpkg install kcenon-thread-system` resolves version 0.3.1 (not 0.3.2)