### PR TITLE
fix(thread): upgrade registry port to v0.3.2

### DIFF
--- a/ports/kcenon-thread-system/vcpkg.json
+++ b/ports/kcenon-thread-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-thread-system",
-  "version-semver": "0.3.1",
-  "port-version": 2,
+  "version-semver": "0.3.2",
+  "port-version": 0,
   "description": "High-performance C++20 multithreading framework with lock-free queues and adaptive optimization",
   "homepage": "https://github.com/kcenon/thread_system",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5,8 +5,8 @@
       "port-version": 1
     },
     "kcenon-thread-system": {
-      "baseline": "0.3.1",
-      "port-version": 2
+      "baseline": "0.3.2",
+      "port-version": 0
     },
     "kcenon-logger-system": {
       "baseline": "0.1.3",

--- a/versions/k-/kcenon-thread-system.json
+++ b/versions/k-/kcenon-thread-system.json
@@ -1,24 +1,14 @@
 {
   "versions": [
     {
+      "version": "0.3.2",
+      "port-version": 0,
+      "git-tree": "b0a464ff2cdd53d471c7409112a2cd2b74e46154"
+    },
+    {
       "version": "0.3.1",
       "port-version": 2,
       "git-tree": "49db4df6b791a5954591f691896f758050c932b1"
-    },
-    {
-      "version": "0.3.2",
-      "port-version": 2,
-      "git-tree": "d5719ace4588f7c19d7e1afbaa6925ea6aeba9f9"
-    },
-    {
-      "version": "0.3.2",
-      "port-version": 1,
-      "git-tree": "5e0e1f5a1240911c203092c6262959b108373b7d"
-    },
-    {
-      "version": "0.3.2",
-      "port-version": 0,
-      "git-tree": "e4744828f2cbe6d077b061c467afa084ba16932a"
     },
     {
       "version": "0.3.1",


### PR DESCRIPTION
Closes #73

## Summary

- Upgrade thread-system registry port from 0.3.1 to 0.3.2 to match the existing `v0.3.2` tag on `kcenon/thread_system`
- Clean orphaned 0.3.2 pv1/pv2 entries from version database
- Fix SHA512/version mismatch: the portfile SHA512 was already pointing to v0.3.2 tarball since the 0.3.2→0.3.1 rollback (#62) did not revert the hash

## What

| File | Change |
|------|--------|
| `ports/kcenon-thread-system/vcpkg.json` | version-semver: 0.3.1 → 0.3.2, port-version: 2 → 0 |
| `versions/baseline.json` | baseline: 0.3.1 → 0.3.2, port-version: 2 → 0 |
| `versions/k-/kcenon-thread-system.json` | Add 0.3.2 pv0 entry with correct git-tree, remove orphaned 0.3.2 pv1/pv2 entries |
| `ports/kcenon-thread-system/portfile.cmake` | No change needed — SHA512 already matches v0.3.2 tarball |

## Why

The v0.3.2 tag now exists on `kcenon/thread_system` (commit `2ca42cd` — "fix(vcpkg): correct usage target name and remove stale fmt dependency"). The previous rollback (#62) reverted the version metadata to 0.3.1 but left the SHA512 pointing to the v0.3.2 tarball, making the 0.3.1 port effectively broken (SHA512 mismatch on download).

## How Verified

- [x] v0.3.2 tag confirmed via `gh api repos/kcenon/thread_system/git/refs/tags/v0.3.2`
- [x] SHA512 verified: v0.3.2 tarball = `7ff506e3...7ccd6` (matches portfile)
- [x] SHA512 verified: v0.3.1 tarball = `9e1bc834...7d51` (does NOT match portfile — confirming the mismatch)
- [x] Version database entry has correct git-tree hash (computed via `git rev-parse HEAD:ports/kcenon-thread-system`)
- [x] No other ports modified
- [x] Code review: APPROVED (all 5 checklist items passed)

## Test Plan

- [ ] `vcpkg install kcenon-thread-system` downloads v0.3.2 tarball and builds successfully
- [ ] `find_package(thread_system CONFIG REQUIRED)` resolves after install
- [ ] Downstream ports (monitoring_system, network_system) still resolve thread_system dependency