### PR TITLE
fix: standardize version-semver scheme in versions DB

### DIFF
--- a/versions/k-/kcenon-common-system.json
+++ b/versions/k-/kcenon-common-system.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2.0",
+      "version-semver": "0.2.0",
       "port-version": 1,
       "git-tree": "6e092ed853205ec1504c2e2cce95ee079bf681e7"
     },
     {
-      "version": "0.2.0",
+      "version-semver": "0.2.0",
       "port-version": 0,
       "git-tree": "a9ddfe0bcfa854e47d785659a1441569f3f3e7b0"
     }

--- a/versions/k-/kcenon-container-system.json
+++ b/versions/k-/kcenon-container-system.json
@@ -11,22 +11,22 @@
       "git-tree": "2d04459058e429c162cc270b6a3bf05abca372f6"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 3,
       "git-tree": "db74acc4844b5d72e2a2dddd89e8760c48f29924"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 2,
       "git-tree": "8c67bf46ecf161d17e5254abb79fc6be8591e842"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 1,
       "git-tree": "fe7a4d9010157c0f0b7e50f5c5fda509218bca72"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 0,
       "git-tree": "a04ae74d2f9e53a1c62b393ac9874eb66061367b"
     }

--- a/versions/k-/kcenon-database-system.json
+++ b/versions/k-/kcenon-database-system.json
@@ -26,27 +26,27 @@
       "git-tree": "d542ae8cb66b26b89112ba7cbd8060b3fbe164e0"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 4,
       "git-tree": "32d6a0eae6da32a650c18ef5713ad8db2dba1f89"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 3,
       "git-tree": "2ae3599a2f0add7ae2e80a484e8700a49656b3ed"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 2,
       "git-tree": "e40fb270f4b5dacfe6b075e81a6963cba7b7e3ec"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 1,
       "git-tree": "a79ca5422c7e406be6443334e425721d314abbff"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 0,
       "git-tree": "fcd3c755ef7760b005c00f7c882db26fb5b1c37a"
     }

--- a/versions/k-/kcenon-logger-system.json
+++ b/versions/k-/kcenon-logger-system.json
@@ -21,42 +21,42 @@
       "git-tree": "bf5e872db50db13ee116f43a40143982729fb6f8"
     },
     {
-      "version": "0.1.3",
+      "version-semver": "0.1.3",
       "port-version": 3,
       "git-tree": "5500dcf02190775fa6d761e6ea51be40c3ce39e2"
     },
     {
-      "version": "0.1.3",
+      "version-semver": "0.1.3",
       "port-version": 2,
       "git-tree": "94594a4d69d8e171383cb76ca431ffb92dd3575b"
     },
     {
-      "version": "0.1.3",
+      "version-semver": "0.1.3",
       "port-version": 1,
       "git-tree": "5b77580f22839a612327b4c5043e5c9d3ad4e006"
     },
     {
-      "version": "0.1.3",
+      "version-semver": "0.1.3",
       "port-version": 0,
       "git-tree": "291d32545ca8ff01efe30db2d10da8fcbc020793"
     },
     {
-      "version": "0.1.2",
+      "version-semver": "0.1.2",
       "port-version": 0,
       "git-tree": "15d3ba335ff8c9e6f0b1f0a88d3ffb82d283120d"
     },
     {
-      "version": "0.1.1",
+      "version-semver": "0.1.1",
       "port-version": 2,
       "git-tree": "3ed7529766802c88afd1e137f20f09e38e495e91"
     },
     {
-      "version": "0.1.1",
+      "version-semver": "0.1.1",
       "port-version": 1,
       "git-tree": "f5d41a77f7f76abe54395eba16a8c6609077e3b3"
     },
     {
-      "version": "0.1.1",
+      "version-semver": "0.1.1",
       "port-version": 0,
       "git-tree": "2648c09e2c46c9a5ab46b944c6b523d2fabde3f2"
     }

--- a/versions/k-/kcenon-monitoring-system.json
+++ b/versions/k-/kcenon-monitoring-system.json
@@ -26,17 +26,17 @@
       "git-tree": "50bab709839d63a39bf2855f8defd1dd41c3398d"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 2,
       "git-tree": "32ce0e9ffa695e2333289010ef1f695776e9b748"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 1,
       "git-tree": "00617b5d3f706716b5b3a705f3b26d49d3f605fb"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 0,
       "git-tree": "b8a7175a4d4c7d603db45f30b7b31e94d72a0181"
     }

--- a/versions/k-/kcenon-network-system.json
+++ b/versions/k-/kcenon-network-system.json
@@ -1,57 +1,57 @@
 {
   "versions": [
     {
-      "version": "0.1.1",
+      "version-semver": "0.1.1",
       "port-version": 7,
       "git-tree": "ae2ce0d4ffede07d2d6ffdf42669eac78faab6ee"
     },
     {
-      "version": "0.1.1",
+      "version-semver": "0.1.1",
       "port-version": 6,
       "git-tree": "4382993e89fe01b038078be871fa7ec047aef6d6"
     },
     {
-      "version": "0.1.1",
+      "version-semver": "0.1.1",
       "port-version": 5,
       "git-tree": "b2dcbd4a6413ec4dcc153311cd70f3706fb18cd6"
     },
     {
-      "version": "0.1.1",
+      "version-semver": "0.1.1",
       "port-version": 4,
       "git-tree": "51cde231d34655aa61f7f231fd675b35fbc788d0"
     },
     {
-      "version": "0.1.1",
+      "version-semver": "0.1.1",
       "port-version": 3,
       "git-tree": "ee80a9731be2356ea39d8e48c7a1c61796f76ab2"
     },
     {
-      "version": "0.1.1",
+      "version-semver": "0.1.1",
       "port-version": 2,
       "git-tree": "a06e43747df36aa5a1fd62934365d4a48de4a567"
     },
     {
-      "version": "0.1.1",
+      "version-semver": "0.1.1",
       "port-version": 1,
       "git-tree": "919fb8d5375f1f62696f47cea1e10623b99ab372"
     },
     {
-      "version": "0.1.1",
+      "version-semver": "0.1.1",
       "port-version": 0,
       "git-tree": "6d168c86acecaf644ca6704821774de276b458eb"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 2,
       "git-tree": "ca7bb88716a0cf9bec6bf239f740b0e723170361"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 1,
       "git-tree": "833d2db76ce925d7b6fc9c23fb865a2ba09c1824"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 0,
       "git-tree": "b5a761a62b4772708a82d9f4ec7fd558a261edb9"
     }

--- a/versions/k-/kcenon-pacs-system.json
+++ b/versions/k-/kcenon-pacs-system.json
@@ -26,27 +26,27 @@
       "git-tree": "b01e5f705f6a0c9fa67c57ab1e47f19b88be02fa"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 4,
       "git-tree": "7dd04845b221c9005ced54d6028b5de8b1e2429e"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 3,
       "git-tree": "410b570ca2c13e76d59e65b0cdc046c19c1493bd"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 2,
       "git-tree": "148688cf857784f92bbfda1ccc8c98d7b2d47fe8"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 1,
       "git-tree": "18badcb103f78bd84f479426b16852e9827c3223"
     },
     {
-      "version": "0.1.0",
+      "version-semver": "0.1.0",
       "port-version": 0,
       "git-tree": "4e47d319474887c8406ae9929ab0efde91b4e56c"
     }

--- a/versions/k-/kcenon-thread-system.json
+++ b/versions/k-/kcenon-thread-system.json
@@ -1,32 +1,32 @@
 {
   "versions": [
     {
-      "version": "0.3.2",
+      "version-semver": "0.3.2",
       "port-version": 0,
       "git-tree": "b0a464ff2cdd53d471c7409112a2cd2b74e46154"
     },
     {
-      "version": "0.3.1",
+      "version-semver": "0.3.1",
       "port-version": 2,
       "git-tree": "49db4df6b791a5954591f691896f758050c932b1"
     },
     {
-      "version": "0.3.1",
+      "version-semver": "0.3.1",
       "port-version": 0,
       "git-tree": "0f6168eea1b095dffe4030fc28ca28058073f6aa"
     },
     {
-      "version": "0.3.0",
+      "version-semver": "0.3.0",
       "port-version": 2,
       "git-tree": "536756c221769c71f8de3b99848e900748b3c72f"
     },
     {
-      "version": "0.3.0",
+      "version-semver": "0.3.0",
       "port-version": 1,
       "git-tree": "f75ee7cefe9cd424ccdf28310b648e636fc929a0"
     },
     {
-      "version": "0.3.0",
+      "version-semver": "0.3.0",
       "port-version": 0,
       "git-tree": "6ba6ba567c419aa9dd6e2fa9a669edbe02f4c856"
     }


### PR DESCRIPTION
## What

### Summary
Standardizes all versions DB entries to use `"version-semver"` instead of plain `"version"`, matching the scheme declared in each port's `vcpkg.json`.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `versions/k-/kcenon-*.json` — All 8 ecosystem port version database files

## Why

### Problem Solved
When a source-local overlay port bumps `port-version` above the registry baseline, vcpkg's manifest-mode version resolver compares the overlay against the versions DB. If the DB uses `"version"` but the port declares `"version-semver"`, the scheme mismatch causes `vcpkg install` to fail immediately.

This was invisible when port-versions matched (no comparison triggered) but blocks portfile sync PRs like kcenon/common_system#628.

### Related Issues
- Fixes kcenon/common_system#629
- Unblocks kcenon/common_system#628 (portfile sync PR)

## Where

### Files Changed
| File | Entries Fixed |
|------|--------------|
| `kcenon-common-system.json` | 2 |
| `kcenon-container-system.json` | 4 |
| `kcenon-database-system.json` | 5 |
| `kcenon-logger-system.json` | 8 |
| `kcenon-monitoring-system.json` | 3 |
| `kcenon-network-system.json` | 11 |
| `kcenon-pacs-system.json` | 5 |
| `kcenon-thread-system.json` | 6 |

## How

### Implementation Details
Replaced all `"version":` keys with `"version-semver":` in versions DB JSON files. The `baseline.json` uses `"baseline"` key and is unaffected.

### Testing Done
- [x] Verified all 8 ports now use consistent `version-semver` scheme
- [x] No `"version":` entries remain in any versions DB file
- [x] `baseline.json` unaffected (uses `"baseline"` key)

### Breaking Changes
None — vcpkg resolves versions by matching the scheme from the port manifest.