### PR TITLE
fix(ports): install usage file in all kcenon portfiles

### DIFF
--- a/ports/kcenon-common-system/portfile.cmake
+++ b/ports/kcenon-common-system/portfile.cmake
@@ -37,3 +37,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/kcenon-common-system/vcpkg.json
+++ b/ports/kcenon-common-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-common-system",
   "version-semver": "0.2.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "High-performance C++20 foundation library providing Result<T> pattern, interfaces, and common utilities",
   "homepage": "https://github.com/kcenon/common_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-container-system/portfile.cmake
+++ b/ports/kcenon-container-system/portfile.cmake
@@ -51,3 +51,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/kcenon-container-system/vcpkg.json
+++ b/ports/kcenon-container-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-container-system",
   "version-semver": "0.1.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Advanced C++20 Container System with Thread-Safe Operations and Messaging Integration",
   "homepage": "https://github.com/kcenon/container_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-database-system/portfile.cmake
+++ b/ports/kcenon-database-system/portfile.cmake
@@ -44,3 +44,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/kcenon-database-system/vcpkg.json
+++ b/ports/kcenon-database-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-database-system",
   "version-semver": "0.1.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Pure, lightweight C++20 Core DAL library with unified access to PostgreSQL, SQLite, MongoDB, and Redis",
   "homepage": "https://github.com/kcenon/database_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-logger-system/portfile.cmake
+++ b/ports/kcenon-logger-system/portfile.cmake
@@ -41,3 +41,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/kcenon-logger-system/vcpkg.json
+++ b/ports/kcenon-logger-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-logger-system",
   "version-semver": "0.1.3",
-  "port-version": 9,
+  "port-version": 10,
   "description": "High-performance C++20 async logging framework with 4.34M msg/sec throughput, 148ns latency, and modular architecture",
   "homepage": "https://github.com/kcenon/logger_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-monitoring-system/portfile.cmake
+++ b/ports/kcenon-monitoring-system/portfile.cmake
@@ -83,3 +83,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/kcenon-monitoring-system/vcpkg.json
+++ b/ports/kcenon-monitoring-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-monitoring-system",
   "version-semver": "0.1.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": "High-performance C++20 monitoring system with metrics collection, distributed tracing, and container monitoring",
   "homepage": "https://github.com/kcenon/monitoring_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-network-system/portfile.cmake
+++ b/ports/kcenon-network-system/portfile.cmake
@@ -64,3 +64,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/kcenon-network-system/vcpkg.json
+++ b/ports/kcenon-network-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-network-system",
   "version-semver": "0.1.1",
-  "port-version": 9,
+  "port-version": 10,
   "description": "Modern C++20 async network library with TCP/UDP, HTTP/1.1, WebSocket, and TLS 1.3 support",
   "homepage": "https://github.com/kcenon/network_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-pacs-system/portfile.cmake
+++ b/ports/kcenon-pacs-system/portfile.cmake
@@ -50,3 +50,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/kcenon-pacs-system/vcpkg.json
+++ b/ports/kcenon-pacs-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-pacs-system",
   "version-semver": "0.1.0",
-  "port-version": 10,
+  "port-version": 11,
   "description": "Modern C++20 PACS (Picture Archiving and Communication System) built on the kcenon ecosystem",
   "homepage": "https://github.com/kcenon/pacs_system",
   "license": "BSD-3-Clause",

--- a/ports/kcenon-thread-system/portfile.cmake
+++ b/ports/kcenon-thread-system/portfile.cmake
@@ -47,3 +47,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/kcenon-thread-system/vcpkg.json
+++ b/ports/kcenon-thread-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-thread-system",
   "version-semver": "0.3.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "High-performance C++20 multithreading framework with lock-free queues and adaptive optimization",
   "homepage": "https://github.com/kcenon/thread_system",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2,35 +2,35 @@
   "default": {
     "kcenon-common-system": {
       "baseline": "0.2.0",
-      "port-version": 2
+      "port-version": 3
     },
     "kcenon-thread-system": {
       "baseline": "0.3.2",
-      "port-version": 1
+      "port-version": 2
     },
     "kcenon-logger-system": {
       "baseline": "0.1.3",
-      "port-version": 9
+      "port-version": 10
     },
     "kcenon-container-system": {
       "baseline": "0.1.0",
-      "port-version": 7
+      "port-version": 8
     },
     "kcenon-monitoring-system": {
       "baseline": "0.1.0",
-      "port-version": 7
+      "port-version": 8
     },
     "kcenon-database-system": {
       "baseline": "0.1.1",
-      "port-version": 3
+      "port-version": 4
     },
     "kcenon-network-system": {
       "baseline": "0.1.1",
-      "port-version": 9
+      "port-version": 10
     },
     "kcenon-pacs-system": {
       "baseline": "0.1.0",
-      "port-version": 10
+      "port-version": 11
     }
   }
 }

--- a/versions/k-/kcenon-common-system.json
+++ b/versions/k-/kcenon-common-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version-semver": "0.2.0",
+      "port-version": 3,
+      "git-tree": "023f95ca9b26424e9b622f73ce7966d7520779ba"
+    },
+    {
+      "version-semver": "0.2.0",
       "port-version": 2,
       "git-tree": "59448896280767360ced497ae55e494ae113ac75"
     },

--- a/versions/k-/kcenon-container-system.json
+++ b/versions/k-/kcenon-container-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version-semver": "0.1.0",
+      "port-version": 8,
+      "git-tree": "57f9bc08a824101cb7e43e6a573cf335028ce1e5"
+    },
+    {
+      "version-semver": "0.1.0",
       "port-version": 7,
       "git-tree": "9452e9cd782373198c209982d3e0b107f511381d"
     },

--- a/versions/k-/kcenon-database-system.json
+++ b/versions/k-/kcenon-database-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version-semver": "0.1.1",
+      "port-version": 4,
+      "git-tree": "f95187609e73c62f2a8387849c607231fb2641f1"
+    },
+    {
+      "version-semver": "0.1.1",
       "port-version": 3,
       "git-tree": "842d585fcc48578173035727caf5a5f9a66a0f16"
     },

--- a/versions/k-/kcenon-logger-system.json
+++ b/versions/k-/kcenon-logger-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version-semver": "0.1.3",
+      "port-version": 10,
+      "git-tree": "665c1a1f74c59e8127cdb78e42437cb4e654ea8f"
+    },
+    {
+      "version-semver": "0.1.3",
       "port-version": 9,
       "git-tree": "65943c7ce8b24c8ee7e59214bc0af3c1b5cfc8d6"
     },

--- a/versions/k-/kcenon-monitoring-system.json
+++ b/versions/k-/kcenon-monitoring-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version-semver": "0.1.0",
+      "port-version": 8,
+      "git-tree": "ffcc40e09c94b3c415c03d1f2b8796841091a25a"
+    },
+    {
+      "version-semver": "0.1.0",
       "port-version": 7,
       "git-tree": "b9ed82bfc9594864366bb156951451f71a4585f0"
     },

--- a/versions/k-/kcenon-network-system.json
+++ b/versions/k-/kcenon-network-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version-semver": "0.1.1",
+      "port-version": 10,
+      "git-tree": "6c4635b78fa8431355f770d7e95bccbbfa03fc1d"
+    },
+    {
+      "version-semver": "0.1.1",
       "port-version": 9,
       "git-tree": "6ea4dc8638bbcfc0977ac08fae30ed64fd3fea1c"
     },

--- a/versions/k-/kcenon-pacs-system.json
+++ b/versions/k-/kcenon-pacs-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version-semver": "0.1.0",
+      "port-version": 11,
+      "git-tree": "45b944c5f5657e5ffcf23abdf9818f467a305bf7"
+    },
+    {
+      "version-semver": "0.1.0",
       "port-version": 10,
       "git-tree": "2aa934698aa4981298a4027e85e9aefca18fbe11"
     },

--- a/versions/k-/kcenon-thread-system.json
+++ b/versions/k-/kcenon-thread-system.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "version-semver": "0.3.2",
+      "port-version": 2,
+      "git-tree": "e05b486aa9afac20deaf8316cb6ba99620df68ea"
+    },
+    {
+      "version-semver": "0.3.2",
       "port-version": 1,
       "git-tree": "97ff1cce9586e2715d8100452cc026ce9231c368"
     },


### PR DESCRIPTION
## What

Adds a single `configure_file` line to each kcenon port's portfile.cmake to install the existing `usage` file to the standard location (`${CURRENT_PACKAGES_DIR}/share/${PORT}/usage`).

## Why

- vcpkg's post-build check fails with `POST_BUILD_CHECKS_FAILED` if a port ships a `usage` file but doesn't install it
- Discovered while submitting kcenon-common-system to microsoft/vcpkg (microsoft/vcpkg#51511) -- all 14 triplets failed at the post-build check
- Fix verified working in upstream PR commit `8e1a35f6` (12/14 triplets pass; remaining 2 are unrelated vcpkg infra)
- Mirroring the upstream-verified fix to the overlay registry hardens it for cold-cache or strict-mode consumers
- Audit of all 8 kcenon ports confirmed every port already ships a `usage` file but none install it

## Where

All 8 kcenon ports were affected. `port-version` bumped accordingly:

| Port | port-version (was -> new) |
|------|---------------------------|
| kcenon-common-system | 2 -> 3 |
| kcenon-thread-system | 1 -> 2 |
| kcenon-container-system | 7 -> 8 |
| kcenon-logger-system | 9 -> 10 |
| kcenon-monitoring-system | 7 -> 8 |
| kcenon-database-system | 3 -> 4 |
| kcenon-network-system | 9 -> 10 |
| kcenon-pacs-system | 10 -> 11 |

## How

For each port, added one line after `vcpkg_install_copyright`:

```cmake
configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
```

Per port:
- Bumped `port-version` in `ports/<port>/vcpkg.json`
- Prepended new entry (newest-first) to `versions/k-/<port>.json`
- Updated port's `port-version` in `versions/baseline.json` (`baseline` semver unchanged)

All 9 JSON files validated with `python3 -c "import json; json.load(open(f))"`.

Closes #89.
Relates to kcenon/common_system#674 (release automation EPIC), microsoft/vcpkg#51511.
