### PR TITLE
ci(e2e): nightly fresh-download to surface masked SHA mismatches

### DIFF
--- a/.github/workflows/validate-e2e.yml
+++ b/.github/workflows/validate-e2e.yml
@@ -5,9 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '17 3 * * *'
 
 env:
-  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+  VCPKG_BINARY_SOURCES: >-
+    ${{ github.event_name == 'schedule' && 'clear' || 'clear;x-gha,readwrite' }}
 
 jobs:
   e2e-test:


### PR DESCRIPTION
## What

Adds a daily fresh-download run of `validate-e2e.yml` so SHA mismatches and other regressions surface within 24 hours instead of being masked indefinitely by the GitHub Actions binary cache.

## Why

The 2026-05-03 audit (kcenon/vcpkg-registry#87, fixed by PR #88) revealed that **all 8 kcenon ports had stale SHA512 values** that passed every weekly run. The cache that should have caught this — `validate-e2e.yml` running each port through vcpkg install — was using `VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"`, which means built binaries hit the GitHub Actions cache and subsequent runs skip the source-download (and SHA-verify) path entirely. SHA verification only ran on the very first cache miss; everything after that was cache hits.

A nightly run with `VCPKG_BINARY_SOURCES: "clear"` forces every install to re-download the archive and re-verify SHA, surfacing this class of regression at most one day after introduction.

## How

Two-line workflow change:

```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
  schedule:
    - cron: '17 3 * * *'   # daily 03:17 UTC, off-peak

env:
  VCPKG_BINARY_SOURCES: >-
    ${{ github.event_name == 'schedule' && 'clear' || 'clear;x-gha,readwrite' }}
```

- `schedule` trigger added (daily, off-peak minute to avoid the :00 herd)
- `VCPKG_BINARY_SOURCES` is now a conditional expression: `clear` (no cache) for cron-triggered runs, original `clear;x-gha,readwrite` for push/PR (preserves fast PR feedback)

## Where

- `.github/workflows/validate-e2e.yml` (only file changed; +4 / -1)

## Testing done

- Workflow yaml is syntactically validated by GitHub on push (PR's own CI run will confirm)
- Conditional expression syntax matches GitHub Actions documentation for `github.event_name`
- Cron expression validates as standard 5-field cron

## Breaking changes

None.

- Existing push/PR runs unchanged
- Nightly job adds ~15-20 minutes of CI time per day (acceptable for an 8-port registry)

Closes #91.

Relates to kcenon/common_system#674 (parent EPIC, hardening sub-task).
