### PR TITLE
ci(e2e): document no-cache rationale and link parent EPIC

### DIFF
--- a/.github/workflows/validate-e2e.yml
+++ b/.github/workflows/validate-e2e.yml
@@ -6,9 +6,23 @@ on:
   pull_request:
     branches: [main]
   schedule:
+    # Daily 03:17 UTC fresh-download run.
+    # Forces every install to re-download the GitHub release archive and
+    # re-verify SHA512 against the value in portfile.cmake. Push/PR runs
+    # keep the GHA binary cache for fast feedback; scheduled runs disable
+    # it so SHA mismatches surface within 24 hours of introduction.
+    #
+    # Background: kcenon/common_system#674 (parent EPIC) and
+    # kcenon/vcpkg-registry#87 (the audit that revealed all 8 ports had
+    # silent SHA512 mismatches because cache hits skip SHA verification).
+    # See kcenon/vcpkg-registry#93 for the no-cache mode rationale.
     - cron: '17 3 * * *'
 
 env:
+  # Conditional binary-source policy:
+  #   schedule -> 'clear'                 (no cache; forces SHA re-verify)
+  #   push/PR  -> 'clear;x-gha,readwrite' (GHA cache; fast feedback)
+  # Required by kcenon/vcpkg-registry#93 (parent: kcenon/common_system#674).
   VCPKG_BINARY_SOURCES: >-
     ${{ github.event_name == 'schedule' && 'clear' || 'clear;x-gha,readwrite' }}
 


### PR DESCRIPTION
## What

Adds inline documentation to `validate-e2e.yml` explaining the no-cache nightly run that was introduced in PR #92, and links the workflow back to the parent EPIC kcenon/common_system#674.

This re-opens the work originally proposed in PR #94, now retargeted to the newly-created `develop` branch in line with the kcenon-wide protected-branch policy ("only `develop` or `release/*` may target `main`").

### Change Type

- [x] Documentation (comments only; no behavioral change)

### Affected Components

- `.github/workflows/validate-e2e.yml` (+14 lines, comments only)

## Why

PR #92 added the `schedule` trigger and the conditional `VCPKG_BINARY_SOURCES` expression that disables the GHA binary cache for cron-triggered runs. The mechanism is correct, but issue #93 explicitly requires the workflow YAML to document WHY no-cache mode exists with a back-link to #674. This PR adds those comments.

### Related Issues

- Part of #93 (acceptance criterion 3 of 3)
- Part of kcenon/common_system#674 (parent EPIC)
- References kcenon/vcpkg-registry#87 (the audit) and PR #92 (the mechanism)
- Replaces the closed PR #94 (same content, retargeted to `develop`)

## Where

| Item | Value |
|------|-------|
| Repository | kcenon/vcpkg-registry |
| File | `.github/workflows/validate-e2e.yml` |
| Diff | +14 / -0 (comment lines only) |
| Base branch | `develop` (newly introduced) |

## How

### Implementation Details

Two comment blocks added:
1. Above the `cron` line under `schedule:` — explains the daily fresh-download intent and links #674, #87, #93.
2. Above the `VCPKG_BINARY_SOURCES` line under `env:` — table-form summary of the conditional behavior.

### Branching note

This PR targets the newly-introduced `develop` branch. Per kcenon branching policy, CI runs only on PRs targeting `main`, so no checks will trigger on this PR. The change is comment-only, and CI will exercise the workflow on the eventual `develop` to `main` release PR.

### Breaking Changes

None.

### Rollback Plan

Revert this commit on `develop`. No infrastructure or data state to undo.

## Notes on AC2 of #93

Issue #93 also lists an acceptance criterion that requires verifying the no-cache mode actually fails on a deliberate SHA mismatch. That remains scoped out and tracked under #93 for follow-up.
