### PR TITLE
chore(release): publish no-cache rationale comments to main

### DIFF
--- a/.github/workflows/validate-e2e.yml
+++ b/.github/workflows/validate-e2e.yml
@@ -6,9 +6,23 @@ on:
   pull_request:
     branches: [main]
   schedule:
+    # Daily 03:17 UTC fresh-download run.
+    # Forces every install to re-download the GitHub release archive and
+    # re-verify SHA512 against the value in portfile.cmake. Push/PR runs
+    # keep the GHA binary cache for fast feedback; scheduled runs disable
+    # it so SHA mismatches surface within 24 hours of introduction.
+    #
+    # Background: kcenon/common_system#674 (parent EPIC) and
+    # kcenon/vcpkg-registry#87 (the audit that revealed all 8 ports had
+    # silent SHA512 mismatches because cache hits skip SHA verification).
+    # See kcenon/vcpkg-registry#93 for the no-cache mode rationale.
     - cron: '17 3 * * *'
 
 env:
+  # Conditional binary-source policy:
+  #   schedule -> 'clear'                 (no cache; forces SHA re-verify)
+  #   push/PR  -> 'clear;x-gha,readwrite' (GHA cache; fast feedback)
+  # Required by kcenon/vcpkg-registry#93 (parent: kcenon/common_system#674).
   VCPKG_BINARY_SOURCES: >-
     ${{ github.event_name == 'schedule' && 'clear' || 'clear;x-gha,readwrite' }}
 


### PR DESCRIPTION
## What

Release PR: brings the documentation update merged to `develop` (PR #95 / commit `b2f72e5`) over to `main`. Comment-only change in `.github/workflows/validate-e2e.yml`; no behavioral change to CI.

### Change Type

- [x] Documentation (release of comment-only change from `develop`)

### Affected Components

- `.github/workflows/validate-e2e.yml` (+14 / -0, comment lines only)

## Why

`develop` is currently 1 commit ahead of `main`. This release flushes that commit through to `main` so the no-cache rationale comments are visible to anyone reading the workflow on the default branch. Per kcenon branching policy, `develop` to `main` requires its own PR with full CI run on `main`.

### Related Issues

- Part of #93 (acceptance criterion 3 of 3 — AC2 still open and intentionally NOT auto-closed by this release)
- Part of kcenon/common_system#674 (parent EPIC)

> **Auto-close suppression**: this release PR deliberately uses "Part of" rather than "Closes/Fixes/Resolves" so issue #93 stays OPEN to track the still-pending AC2 (deliberate SHA-mismatch verification). The squash commit body will be customized at merge time to avoid leaking "Closes #93." from the `develop` squash commit (`b2f72e5`).

## Where

| Item | Value |
|------|-------|
| Repository | kcenon/vcpkg-registry |
| Source branch | `develop` (1 commit ahead of `main`) |
| Target branch | `main` |
| Diff | +14 / -0 (comments only) |

## How

### Implementation

No new code authored — this PR releases an already-merged `develop` commit to `main`.

### Testing Done

CI on `main` will exercise the full E2E port-validation matrix (push/PR triggers keep the GHA binary cache on, so this is a fast cached run).

### Test Plan for Reviewers

1. Confirm the diff contains only comment additions (`# ...` lines) under `schedule:` and `env:`.
2. Confirm CI passes on this PR — same checks as PR #95 plus the main-branch CI gate.

### Breaking Changes

None.

### Rollback Plan

Revert the squash merge commit on `main`. Documentation-only.

### Post-merge follow-up

- Delete and recreate `develop` from `main` HEAD per kcenon branching policy ("After release merge: delete `develop`, recreate from `main`").
- Continue tracking AC2 of #93 as separate work.
